### PR TITLE
chore!: Bump @types/vscode from 1.81.0 to 1.90.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/minimist": "^1.2.5",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.14.2",
-        "@types/vscode": "^1.81.0",
+        "@types/vscode": "^1.90.0",
         "@vscode/test-electron": "^2.4.0",
         "@vscode/test-web": "^0.0.54",
         "@vscode/vsce": "^2.27.0",
@@ -822,10 +822,11 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.81.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.81.0.tgz",
-      "integrity": "sha512-YIaCwpT+O2E7WOMq0eCgBEABE++SX3Yl/O02GoMIF2DO3qAtvw7m6BXFYsxnc6XyzwZgh6/s/UG78LSSombl2w==",
-      "dev": true
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
+      "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vscode/test-electron": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/minimist": "^1.2.5",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.14.2",
-    "@types/vscode": "^1.81.0",
+    "@types/vscode": "^1.90.0",
     "@vscode/test-electron": "^2.4.0",
     "@vscode/test-web": "^0.0.54",
     "@vscode/vsce": "^2.27.0",


### PR DESCRIPTION
Preparation for using "@vscode/wasm-wasi@1.0.0-pre.2".
