### PR TITLE
chore: Use '@vscode/wasm-wasi/v1' instead of '@vscode/wasm-wasi'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
-        "@vscode/wasm-wasi": "^0.13.0-pre.1",
+        "@vscode/wasm-wasi": "^1.0.0-pre.2",
         "minimist": "^1.2.8"
       },
       "devDependencies": {
@@ -34,7 +34,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "vscode": "^1.81.0"
+        "vscode": "^1.90.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -1197,19 +1197,20 @@
       }
     },
     "node_modules/@vscode/wasm-wasi": {
-      "version": "0.13.0-pre.1",
-      "resolved": "https://registry.npmjs.org/@vscode/wasm-wasi/-/wasm-wasi-0.13.0-pre.1.tgz",
-      "integrity": "sha512-1w3GSGjuoWA66FQ6asO1io4UmyjnmbFgi+dFrM+uUrKBJ7Wd/Y0Eac2KfBo1hickdyGWKlS4nJj3ztBkyuv//g==",
+      "version": "1.0.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@vscode/wasm-wasi/-/wasm-wasi-1.0.0-pre.2.tgz",
+      "integrity": "sha512-szyy1yLbAeLUbB60+pVHPMm2qx+zjR60TeJD/TVzqHNbdEU7NZtqQ02pdCE8g4UUrnSgM/wm7olIxPF+WqNS1g==",
+      "license": "MIT",
       "dependencies": {
-        "semver": "^7.5.1",
+        "semver": "^7.6.2",
         "yargs": "^17.7.2"
       },
       "bin": {
         "dir-dump": "bin/dir-dump"
       },
       "engines": {
-        "node": ">=16.17.1",
-        "vscode": "^1.78.0"
+        "node": ">=20.9.0",
+        "vscode": "^1.88.0"
       }
     },
     "node_modules/@zeit/schemas": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ms-vscode.webshell"
   ],
   "dependencies": {
-    "@vscode/wasm-wasi": "^0.13.0-pre.1",
+    "@vscode/wasm-wasi": "^1.0.0-pre.2",
     "minimist": "^1.2.8"
   },
   "devDependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import {
   RootFileSystem,
   Stdio,
   WasmProcess
-} from '@vscode/wasm-wasi'
+} from '@vscode/wasm-wasi/v1'
 //import minimist from 'minimist'
 import { argsForRun, memoryDescriptor, normalizeFullPath } from './lib/args'
 


### PR DESCRIPTION
Preparing for the update of the WASM WASI Core extension(#183).
